### PR TITLE
Remove logging of session and JWT payloads in auth callbacks

### DIFF
--- a/src/app/api/auth/[...nextauth]/options.ts
+++ b/src/app/api/auth/[...nextauth]/options.ts
@@ -52,7 +52,6 @@ export const options: NextAuthOptions = {
 
     callbacks: {
         session: ({ session, token }) => {
-            console.log('Session Callback', { session, token })
             return {
                 ...session,
                 user: {
@@ -62,7 +61,6 @@ export const options: NextAuthOptions = {
             }
         },
         jwt: ({ token, user }) => {
-            console.log('JWT Callback', { token, user })
             if (user) {
                 const u = user as unknown as any
                 return {


### PR DESCRIPTION
The `session` and `jwt` callbacks in `src/app/api/auth/[...nextauth]/options.ts` logged their full payloads (session contents and JWT data) on every authenticated request, writing sensitive values into production logs.

This removes both `console.log` statements. No behavioural change otherwise.

Closes #333