### PR TITLE
Use a shared PrismaClient singleton for auth

### DIFF
--- a/src/app/api/auth/[...nextauth]/options.ts
+++ b/src/app/api/auth/[...nextauth]/options.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import { compare } from 'bcrypt';
 import type { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
@@ -20,8 +20,6 @@ export const options: NextAuthOptions = {
                 }
             },
             async authorize(credentials) {
-                const prisma = new PrismaClient()
-
                 if (!credentials?.password || !credentials.username) {
                     return null;
                 }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = prisma;
+}


### PR DESCRIPTION
`authorize()` in `src/app/api/auth/[...nextauth]/options.ts` created a `new PrismaClient()` on every login attempt and never disconnected it. Each instance opens its own connection pool, so repeated sign-ins (or a brute-force run) could exhaust Postgres connections, and every login paid client-instantiation latency.

- Adds `src/lib/prisma.ts` with the standard `globalThis` singleton pattern (cached in dev to survive HMR; single module-level instance in production)
- `authorize()` now imports the shared client

Verified with lint and a full production build.

Closes #334