### PR TITLE
Rate limit failed login attempts by source IP

### DIFF
--- a/src/app/api/auth/[...nextauth]/options.ts
+++ b/src/app/api/auth/[...nextauth]/options.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { clearFailures, isRateLimited, recordFailure } from '@/lib/rateLimit';
 import { compare } from 'bcrypt';
 import type { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
@@ -19,8 +20,13 @@ export const options: NextAuthOptions = {
                     placeholder: 'PWizzle'
                 }
             },
-            async authorize(credentials) {
+            async authorize(credentials, req) {
                 if (!credentials?.password || !credentials.username) {
+                    return null;
+                }
+                const forwardedFor = req.headers?.['x-forwarded-for'];
+                const ip = (Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor)?.split(',')[0]?.trim() ?? 'unknown';
+                if (isRateLimited(ip)) {
                     return null;
                 }
                 const user = await prisma.applicationUser.findUnique({
@@ -28,6 +34,7 @@ export const options: NextAuthOptions = {
                 })
 
                 if (!user) {
+                    recordFailure(ip);
                     return null;
                 }
                 const isPasswordValid = await compare(
@@ -35,8 +42,10 @@ export const options: NextAuthOptions = {
                     user.password
                 )
                 if (!isPasswordValid) {
+                    recordFailure(ip);
                     return null
                 }
+                clearFailures(ip);
 
                 return {
                     id: user.id + '',

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,42 @@
+const WINDOW_MS = 15 * 60 * 1000;
+const MAX_FAILURES = 5;
+const MAX_TRACKED_KEYS = 10_000;
+
+type FailureWindow = { count: number; resetAt: number };
+
+// In-memory, so limits apply per serverless instance. Vercel's Fluid
+// Compute reuses instances across requests, which makes this effective
+// against bursts from a single source, but a platform-level WAF rule is
+// still the stronger guarantee across instances.
+const failures = new Map<string, FailureWindow>();
+
+const prune = (now: number) => {
+    if (failures.size < MAX_TRACKED_KEYS) {
+        return;
+    }
+    failures.forEach((window, key) => {
+        if (now > window.resetAt) {
+            failures.delete(key);
+        }
+    });
+};
+
+export const isRateLimited = (key: string): boolean => {
+    const window = failures.get(key);
+    return !!window && Date.now() <= window.resetAt && window.count >= MAX_FAILURES;
+};
+
+export const recordFailure = (key: string): void => {
+    const now = Date.now();
+    prune(now);
+    const window = failures.get(key);
+    if (!window || now > window.resetAt) {
+        failures.set(key, { count: 1, resetAt: now + WINDOW_MS });
+        return;
+    }
+    window.count++;
+};
+
+export const clearFailures = (key: string): void => {
+    failures.delete(key);
+};


### PR DESCRIPTION
Adds brute-force protection to the credentials login (#335) with no new dependencies or infrastructure:

- `src/lib/rateLimit.ts` — small in-memory fixed-window limiter: **5 failed attempts per IP → 15-minute lockout**, with pruning to bound memory
- `authorize()` now checks the limit before hitting the database, records failures (unknown user or wrong password), and clears the counter on successful sign-in
- IP taken from the first hop of `x-forwarded-for` (set by Vercel's proxy)

Being in-memory, the limit applies per serverless instance — effective against single-source bursts on Fluid Compute (instances are reused), but not a cross-instance guarantee. A Vercel WAF rate-limit rule on `/api/auth/*` is the stronger complement and can be added from the dashboard; noted in the code comment.

Verified with lint, tsc, and a full production build.

Closes #335