### PR TITLE
Drop AWS credentials by sending S3 listing requests unsigned

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,13 @@ const bucket = 'the-maggie-zone-images'
 
 const Page: React.FC = async () => {
 
-    const s3Client = new S3Client({ region: 'eu-west-1', });
+    // The bucket policy grants public ListBucket/GetObject, so requests are
+    // sent unsigned and the app needs no AWS credentials.
+    const s3Client = new S3Client({
+        region: 'eu-west-1',
+        signer: { sign: async (request) => request },
+        credentials: { accessKeyId: '', secretAccessKey: '' },
+    });
     const s3Url = `https://${bucket}.s3.eu-west-1.amazonaws.com`
     const paginator = paginateListObjectsV2(
         { client: s3Client },


### PR DESCRIPTION
While auditing #336 I found the bucket policy on `the-maggie-zone-images` already grants **public** `s3:ListBucket` and `s3:GetObject` to `Principal: "*"` — so the app's only AWS call (`ListObjectsV2` on the homepage) doesn't need credentials at all.

This configures the S3 client to send requests unsigned (signer pass-through + inert empty credentials so the SDK skips its credential-provider chain). Verified locally: with `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` removed from the environment entirely, the listing returns all 65 objects.

### Follow-up (manual, after merge)
1. Remove `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` from the Vercel project env (and local `.env`)
2. Deactivate/delete the access keys for IAM user `maggie` (account 297374559677) — probing showed the key also has account-wide `s3:ListAllMyBuckets`, so retiring it is strictly better than re-scoping

Closes #336