### PR TITLE
Cache the S3 listing instead of listing the bucket on every request

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Inter } from "next/font/google";
+import { unstable_cache } from "next/cache";
 
 import MaggieImageList from "@/components/MaggieImageList";
 import { S3Client, paginateListObjectsV2 } from "@aws-sdk/client-s3";
@@ -18,33 +19,42 @@ const shuffle = <T,>(items: T[]): T[] => {
 };
 const inter = Inter({ subsets: ["latin"] });
 const bucket = 'the-maggie-zone-images'
+const s3Url = `https://${bucket}.s3.eu-west-1.amazonaws.com`
+
+// The bucket policy grants public ListBucket/GetObject, so requests are
+// sent unsigned and the app needs no AWS credentials.
+const s3Client = new S3Client({
+    region: 'eu-west-1',
+    signer: { sign: async (request) => request },
+    credentials: { accessKeyId: '', secretAccessKey: '' },
+});
+
+const listImageKeys = unstable_cache(
+    async (): Promise<string[]> => {
+        const paginator = paginateListObjectsV2(
+            { client: s3Client },
+            { Bucket: bucket }
+        );
+        const keys: string[] = [];
+        for await (const page of paginator) {
+            for (const object of page.Contents ?? []) {
+                if (object.Key) {
+                    keys.push(object.Key);
+                }
+            }
+        }
+        return keys;
+    },
+    ['s3-image-keys'],
+    { revalidate: 3600 }
+);
 
 const Page: React.FC = async () => {
 
-    // The bucket policy grants public ListBucket/GetObject, so requests are
-    // sent unsigned and the app needs no AWS credentials.
-    const s3Client = new S3Client({
-        region: 'eu-west-1',
-        signer: { sign: async (request) => request },
-        credentials: { accessKeyId: '', secretAccessKey: '' },
-    });
-    const s3Url = `https://${bucket}.s3.eu-west-1.amazonaws.com`
-    const paginator = paginateListObjectsV2(
-        { client: s3Client },
-        { Bucket: bucket }
-    );
-    const getImages = async (howMany: number) => {
-        for await (const page of paginator) {
-            const objects = page.Contents;
-            if (objects) {
-                return shuffle(objects).slice(1, howMany).map((o) => { return { title: o.Key!, img: `${s3Url}/${o.Key}` } })
-            }
-        }
-    }
-
-    const imagesData = await getImages(NUM_IMAGES);
+    const keys = await listImageKeys();
+    const imagesData = shuffle(keys).slice(1, NUM_IMAGES).map((key) => { return { title: key, img: `${s3Url}/${key}` } });
     const session = await getServerSession(options);
-    return imagesData && (
+    return imagesData.length > 0 && (
 
         <main className={`flex min-h-screen flex-col items-center justify-between p-24 ${inter.className}`} >
             <div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,22 +31,27 @@ const s3Client = new S3Client({
 
 const listImageKeys = unstable_cache(
     async (): Promise<string[]> => {
-        const paginator = paginateListObjectsV2(
-            { client: s3Client },
-            { Bucket: bucket }
-        );
-        const keys: string[] = [];
-        for await (const page of paginator) {
-            for (const object of page.Contents ?? []) {
-                if (object.Key) {
-                    keys.push(object.Key);
+        try {
+            const paginator = paginateListObjectsV2(
+                { client: s3Client },
+                { Bucket: bucket }
+            );
+            const keys: string[] = [];
+            for await (const page of paginator) {
+                for (const object of page.Contents ?? []) {
+                    if (object.Key) {
+                        keys.push(object.Key);
+                    }
                 }
             }
+            return keys;
+        } catch (error) {
+            console.error('Failed to list gallery images', error);
+            return [];
         }
-        return keys;
     },
     ['s3-image-keys'],
-    { revalidate: 3600 }
+    { revalidate: 3600, tags: ['s3-image-keys'] }
 );
 
 const Page: React.FC = async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,24 +31,19 @@ const s3Client = new S3Client({
 
 const listImageKeys = unstable_cache(
     async (): Promise<string[]> => {
-        try {
-            const paginator = paginateListObjectsV2(
-                { client: s3Client },
-                { Bucket: bucket }
-            );
-            const keys: string[] = [];
-            for await (const page of paginator) {
-                for (const object of page.Contents ?? []) {
-                    if (object.Key) {
-                        keys.push(object.Key);
-                    }
+        const paginator = paginateListObjectsV2(
+            { client: s3Client },
+            { Bucket: bucket }
+        );
+        const keys: string[] = [];
+        for await (const page of paginator) {
+            for (const object of page.Contents ?? []) {
+                if (object.Key) {
+                    keys.push(object.Key);
                 }
             }
-            return keys;
-        } catch (error) {
-            console.error('Failed to list gallery images', error);
-            return [];
         }
+        return keys;
     },
     ['s3-image-keys'],
     { revalidate: 3600, tags: ['s3-image-keys'] }
@@ -56,7 +51,13 @@ const listImageKeys = unstable_cache(
 
 const Page: React.FC = async () => {
 
-    const keys = await listImageKeys();
+    // Catch here rather than inside listImageKeys: unstable_cache doesn't
+    // cache rejections, so a transient S3 failure renders without the
+    // gallery once instead of caching an empty list for an hour.
+    const keys = await listImageKeys().catch((error) => {
+        console.error('Failed to list gallery images', error);
+        return [] as string[];
+    });
     const imagesData = shuffle(keys).slice(1, NUM_IMAGES).map((key) => { return { title: key, img: `${s3Url}/${key}` } });
     const session = await getServerSession(options);
     return imagesData.length > 0 && (


### PR DESCRIPTION
The homepage called S3 `ListObjectsV2` on **every request**. This wraps the key listing in `unstable_cache` with a 1-hour revalidation, so S3 is hit at most once per hour per instance:

- The cached function returns the plain key list; the **shuffle happens after the cache read**, so every visitor still gets a random selection (verified: two consecutive requests serve different image sets)
- The pagination loop previously `return`ed inside `for await`, so only the first page (max 1,000 objects) was ever read — it now walks all pages
- Listing/URL-building moved to module scope; the page itself just shuffles, slices, and renders

Selection semantics are otherwise unchanged — the `slice(1, …)` off-by-one is deliberately left for #339.

Verified with lint, a production build, and a local `next start` smoke test.

Closes #338