### PR TITLE
Show all 10 gallery images instead of dropping one

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ const listImageKeys = unstable_cache(
         const keys: string[] = [];
         for await (const page of paginator) {
             for (const object of page.Contents ?? []) {
-                if (object.Key) {
+                if (object.Key && !object.Key.endsWith('/')) {
                     keys.push(object.Key);
                 }
             }
@@ -58,7 +58,7 @@ const Page: React.FC = async () => {
         console.error('Failed to list gallery images', error);
         return [] as string[];
     });
-    const imagesData = shuffle(keys).slice(1, NUM_IMAGES).map((key) => { return { title: key, img: `${s3Url}/${key}` } });
+    const imagesData = shuffle(keys).slice(0, NUM_IMAGES).map((key) => { return { title: key, img: `${s3Url}/${key}` } });
     const session = await getServerSession(options);
     return imagesData.length > 0 && (
 


### PR DESCRIPTION
Fixes the off-by-one in the homepage image selection (#339):

- `slice(1, howMany)` skipped the first element of the *shuffled* array, so every page load discarded one random image and rendered 9 instead of `NUM_IMAGES = 10`
- The `slice(1)` was presumably meant to skip an S3 folder-marker key, but I checked the bucket: all 65 objects are real images, no zero-byte/folder keys exist. And since the skip ran after shuffling, it never reliably targeted a folder key anyway
- Now: filter out any key ending in `/` (guards against future folder markers), then `slice(0, howMany)`

Verified with lint, a production build, and a local `next start` check — the homepage now renders exactly 10 distinct images.

Note: this overlaps with #358 (cached S3 listing) on the same lines; whichever merges second needs a trivial rebase, which I'll handle.

Closes #339