### PR TITLE
Fix Next.js deprecations: viewport export and image remotePatterns

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,12 @@ const nextConfig = {
   reactStrictMode: true,
   trailingSlash: true,
   images: {
-    domains: ['the-maggie-zone-images.s3.eu-west-1.amazonaws.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'the-maggie-zone-images.s3.eu-west-1.amazonaws.com',
+      },
+    ],
   },
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next'
+import { Metadata, Viewport } from 'next'
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import '../styles/globals.css'
@@ -6,7 +6,10 @@ import '../styles/globals.css'
 export const metadata: Metadata = {
   title: 'Welcome to the Maggie.Zone',
   description: 'A website for my dog',
-  themeColor: '#723d8f'
+}
+
+export const viewport: Viewport = {
+  themeColor: '#723d8f',
 }
 
 export default function RootLayout({


### PR DESCRIPTION
Closes #343. Two deprecated APIs updated:

- `metadata.themeColor` → dedicated `viewport` export in `src/app/layout.tsx` (this also silences the deprecation warning Next printed on every render)
- `images.domains` → `images.remotePatterns` in `next.config.js`, scoped to `https` on the S3 host (`remotePatterns` is also slightly stricter than `domains`, which allowed any protocol)

Verified with lint, a production build, and a `next start` smoke test: `<meta name="theme-color" content="#723d8f"/>` still renders, gallery images still go through `/_next/image`, and the per-render themeColor warning is gone from the server log.