### PR TITLE
Measure image dimensions and blur placeholders at runtime, cached per photo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,11 @@ const listImageKeys = unstable_cache(
 const measureImage = (key: string) =>
     unstable_cache(
         async () => {
-            const response = await fetch(`${s3Url}/${encodeURI(key)}`);
+            // Fail fast on a stalled connection so the photo is dropped from
+            // the render instead of hanging the whole page.
+            const response = await fetch(`${s3Url}/${encodeURI(key)}`, {
+                signal: AbortSignal.timeout(10_000),
+            });
             if (!response.ok) {
                 throw new Error(`Fetching ${key} failed: ${response.status}`);
             }
@@ -95,7 +99,7 @@ const Page: React.FC = async () => {
         shuffle(keys).slice(0, NUM_IMAGES).map(async (key): Promise<imageWithTitle | null> => {
             try {
                 const meta = await measureImage(key);
-                return { title: key, img: `${s3Url}/${key}`, ...meta };
+                return { title: key, img: `${s3Url}/${encodeURI(key)}`, ...meta };
             } catch (error) {
                 console.error(`Failed to measure gallery image ${key}`, error);
                 return null;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,11 @@ import { S3Client, paginateListObjectsV2 } from "@aws-sdk/client-s3";
 import { LoginButton, LogoutButton } from "./components/Buttons";
 import { getServerSession } from "next-auth";
 import { options } from "./api/auth/[...nextauth]/options";
+import { imageWithTitle } from "@/types";
+import sharp from "sharp";
 
 const NUM_IMAGES = 10;
+const BLUR_WIDTH = 16;
 
 const shuffle = <T,>(items: T[]): T[] => {
     const result = [...items];
@@ -49,6 +52,36 @@ const listImageKeys = unstable_cache(
     { revalidate: 3600, tags: ['s3-image-keys'] }
 );
 
+// Measures a photo's real dimensions and builds a blur placeholder.
+// Photos are immutable (a new photo gets a new key), so entries are
+// cached without revalidation; each image is downloaded at most once
+// per deployment.
+const measureImage = (key: string) =>
+    unstable_cache(
+        async () => {
+            const response = await fetch(`${s3Url}/${encodeURI(key)}`);
+            if (!response.ok) {
+                throw new Error(`Fetching ${key} failed: ${response.status}`);
+            }
+            const image = sharp(Buffer.from(await response.arrayBuffer()));
+            const { width, height, orientation } = await image.metadata();
+            if (!width || !height) {
+                throw new Error(`Could not read dimensions of ${key}`);
+            }
+            // EXIF orientations 5-8 display rotated 90°, swapping the axes;
+            // .rotate() bakes the same rotation into the placeholder.
+            const displaysRotated = (orientation ?? 1) >= 5;
+            const blur = await image.rotate().resize(BLUR_WIDTH).jpeg({ quality: 60 }).toBuffer();
+            return {
+                width: displaysRotated ? height : width,
+                height: displaysRotated ? width : height,
+                blurDataURL: `data:image/jpeg;base64,${blur.toString('base64')}`,
+            };
+        },
+        ['image-meta', key],
+        { revalidate: false }
+    )();
+
 const Page: React.FC = async () => {
 
     // Catch here rather than inside listImageKeys: unstable_cache doesn't
@@ -58,7 +91,17 @@ const Page: React.FC = async () => {
         console.error('Failed to list gallery images', error);
         return [] as string[];
     });
-    const imagesData = shuffle(keys).slice(0, NUM_IMAGES).map((key) => { return { title: key, img: `${s3Url}/${key}` } });
+    const imagesData = (await Promise.all(
+        shuffle(keys).slice(0, NUM_IMAGES).map(async (key): Promise<imageWithTitle | null> => {
+            try {
+                const meta = await measureImage(key);
+                return { title: key, img: `${s3Url}/${key}`, ...meta };
+            } catch (error) {
+                console.error(`Failed to measure gallery image ${key}`, error);
+                return null;
+            }
+        })
+    )).filter((image): image is imageWithTitle => image !== null);
     const session = await getServerSession(options);
     return imagesData.length > 0 && (
 

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -42,8 +42,10 @@ const ImageModal: FC<ImageModalProps> = ({ image, onClose }) => {
         <Image
           src={image.img}
           alt={image.title}
-          height={1200}
-          width={1200}
+          width={image.width}
+          height={image.height}
+          placeholder='blur'
+          blurDataURL={image.blurDataURL}
           className='max-h-[90vh] max-w-[90vw] w-auto h-auto'
         />
       )}

--- a/src/components/MaggieImageList.tsx
+++ b/src/components/MaggieImageList.tsx
@@ -28,8 +28,10 @@ const MaggieImageList: FC<MaggieImageListProps> = ({ images }) => {
                 src={item.img}
                 alt={item.title}
                 loading='lazy'
-                width={1000}
-                height={1000}
+                width={item.width}
+                height={item.height}
+                placeholder='blur'
+                blurDataURL={item.blurDataURL}
               />
             </button>
           </li>

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,9 @@ import { StaticImageData } from "next/image"
 export type imageWithTitle = {
   img: string;
   title: string;
+  width: number;
+  height: number;
+  blurDataURL: string;
 };
 
 export type Post = {


### PR DESCRIPTION
Closes #348. Eliminates gallery layout shift and adds blur-up loading — **measured at runtime, no committed manifest**, so uploading photos to the bucket keeps requiring zero code changes (they appear within the hourly listing cache as before).

### How it works
- `measureImage(key)`: downloads the photo once, reads real `width`/`height` and builds a 16px base64 `blurDataURL` with `sharp`, wrapped in `unstable_cache` keyed per photo with `revalidate: false` — photos are immutable (new photo = new key), so each is measured at most once per deployment
- The page measures only the 10 photos it's about to render (`Promise.all` after the shuffle); a photo that fails to measure is logged and dropped from that render instead of crashing the page
- EXIF orientations 5–8 display rotated 90°, so the axes are swapped and `.rotate()` bakes the same rotation into the placeholder
- Gallery and modal images now carry real dimensions (stable `aspect-ratio` from first paint → no masonry reflow) and `placeholder="blur"`

### Verified
Lint + build pass; `next start` shows 10 images with real varied dimensions (853×1280, 1280×854, …) and inline blur placeholders; repeat requests serve from cache (~200 ms full page render).