### PR TITLE
Add sizes to gallery images so browsers stop downloading oversized sources

### DIFF
--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -44,6 +44,7 @@ const ImageModal: FC<ImageModalProps> = ({ image, onClose }) => {
           alt={image.title}
           width={image.width}
           height={image.height}
+          sizes='90vw'
           placeholder='blur'
           blurDataURL={image.blurDataURL}
           className='max-h-[90vh] max-w-[90vw] w-auto h-auto'

--- a/src/components/MaggieImageList.tsx
+++ b/src/components/MaggieImageList.tsx
@@ -30,6 +30,7 @@ const MaggieImageList: FC<MaggieImageListProps> = ({ images }) => {
                 loading='lazy'
                 width={item.width}
                 height={item.height}
+                sizes='33vw'
                 placeholder='blur'
                 blurDataURL={item.blurDataURL}
               />


### PR DESCRIPTION
Closes #345.

- Grid thumbnails: `sizes='33vw'`, matching the current 3-column masonry (if #346 later makes the column count responsive, this string updates with it)
- Modal image: `sizes='90vw'`, matching its `max-w-[90vw]` constraint

With `sizes` set, next/image emits the full 256w–3840w srcset and browsers pick by actual rendered width — e.g. a 1440px desktop now grabs the 640w candidate per thumbnail instead of 1080–1920w, and phones drop to 256–384w. Verified in the rendered HTML (`sizes="33vw"` on all 10 images, full srcset present).