### PR TITLE
Responsive gallery columns and thumbnail hover polish

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -109,7 +109,7 @@ const Page: React.FC = async () => {
     const session = await getServerSession(options);
     return imagesData.length > 0 && (
 
-        <main className={`flex min-h-screen flex-col items-center justify-between p-24 ${inter.className}`} >
+        <main className={`flex min-h-screen flex-col items-center justify-between p-6 md:p-24 ${inter.className}`} >
             <div>
                 <div className="authButton">
                     {session ? <LogoutButton /> : <LoginButton /> }

--- a/src/components/MaggieImageList.tsx
+++ b/src/components/MaggieImageList.tsx
@@ -14,9 +14,9 @@ const MaggieImageList: FC<MaggieImageListProps> = ({ images }) => {
   const [selectedImage, setSelectedImage] = useState<imageWithTitle | null>(null);
   return (
     <>
-      <ul className='my-10 columns-3 gap-[5px] list-none p-0'>
+      <ul className='my-10 columns-2 md:columns-3 lg:columns-4 gap-2 list-none p-0'>
         {images.map((item) => (
-          <li key={item.img} className='mb-[5px] break-inside-avoid'>
+          <li key={item.img} className='mb-2 break-inside-avoid'>
             <button
               type='button'
               className='block w-full cursor-pointer border-0 bg-transparent p-0'
@@ -24,13 +24,13 @@ const MaggieImageList: FC<MaggieImageListProps> = ({ images }) => {
               aria-label={`View ${item.title}`}
             >
               <Image
-                className='w-full h-auto'
+                className='w-full h-auto rounded-lg transition duration-200 hover:scale-[1.02] hover:shadow-lg'
                 src={item.img}
                 alt={item.title}
                 loading='lazy'
                 width={item.width}
                 height={item.height}
-                sizes='33vw'
+                sizes='(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw'
                 placeholder='blur'
                 blurDataURL={item.blurDataURL}
               />


### PR DESCRIPTION
Closes #346.

- **Columns**: `columns-2 md:columns-3 lg:columns-4` — phones get 2 readable columns instead of 3 postage stamps; large screens get 4
- **Padding**: the page wrapper's fixed `p-24` (6rem each side — brutal on a 390px phone) relaxes to `p-6 md:p-24`
- **`sizes` follows the breakpoints**: `(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw`, keeping #345's byte savings accurate at every width
- **Polish**: rounded corners, subtle hover scale (1.02) + shadow with a 200ms transition; gap bumped 5px → 8px to breathe with the rounded corners
- **Fade-in on lazy load**: deliberately not added as a separate mechanism — the blur-up placeholders from #364 already provide the progressive load-in, and layering an opacity transition on top would double-animate

Verified: lint + build pass; rendered HTML carries the responsive column classes, updated `sizes` on all 10 images, and hover classes; built CSS contains the emitted utilities.