### PR TITLE
Modernize lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,19 +6,21 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: Preview
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
Closes #344

- Bumps deprecated `actions/checkout@v3` and `actions/setup-node@v3` to v4, matching the CI conventions in the Wedding repo
- Removes the `environment: Preview` gate — a plain lint job doesn't need an environment
- Bumps the Node matrix from 20.x to 22.x/24.x (Vercel's current default is Node 24)
- Adds an explicit `permissions: contents: read` block

The job id stays `build` so any required status checks referencing it keep working.