### PR TITLE
Guard drop-tables migration against production schema drift

### DIFF
--- a/prisma/migrations/20260724000000_drop_unused_tables/migration.sql
+++ b/prisma/migrations/20260724000000_drop_unused_tables/migration.sql
@@ -5,15 +5,18 @@
   - You are about to drop the `Post` table. If the table is not empty, all the data it contains will be lost.
   - You are about to drop the `Weight` table. If the table is not empty, all the data it contains will be lost.
 
+  The production database has drifted from the migration history (the
+  Weight foreign key is missing there), so every statement is guarded
+  with IF EXISTS to drop whatever subset of these objects is present.
 */
 -- DropForeignKey
-ALTER TABLE "Weight" DROP CONSTRAINT "Weight_userId_fkey";
+ALTER TABLE IF EXISTS "Weight" DROP CONSTRAINT IF EXISTS "Weight_userId_fkey";
 
 -- DropTable
-DROP TABLE "Image";
+DROP TABLE IF EXISTS "Image";
 
 -- DropTable
-DROP TABLE "Post";
+DROP TABLE IF EXISTS "Post";
 
 -- DropTable
-DROP TABLE "Weight";
+DROP TABLE IF EXISTS "Weight";


### PR DESCRIPTION
The `20260724000000_drop_unused_tables` migration from #377 failed on the production deploy with P3018: `constraint "Weight_userId_fkey" of relation "Weight" does not exist` — the prod database has drifted from the migration history.

This guards every statement with `IF EXISTS` (including `ALTER TABLE IF EXISTS`, in case the tables themselves are missing too), so the migration drops whichever of the dead objects actually exist. Editing the migration in place is the documented Prisma recovery for a failed migration: it ran in a transaction, so nothing was applied.

Verified against a throwaway Postgres 16 container in two scenarios: tables present but constraint missing (the exact prod failure), and nothing present at all — both pass, with only skip notices.

### Recovery steps after merging
Prisma blocks all deploys until the failed migration is resolved. Run once against prod:

```
DATABASE_URL="<prod url>" npx prisma migrate resolve --rolled-back 20260724000000_drop_unused_tables
```

Then redeploy (the merge itself will trigger one) — `migrate deploy` will re-apply the fixed migration.