### PR TITLE
Show friendly captions instead of raw filenames

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { LoginButton, LogoutButton } from "./components/Buttons";
 import { getServerSession } from "next-auth";
 import { options } from "./api/auth/[...nextauth]/options";
 import { imageWithTitle } from "@/types";
+import { captionFor } from "@/lib/captions";
 import sharp from "sharp";
 
 const NUM_IMAGES = 10;
@@ -99,7 +100,7 @@ const Page: React.FC = async () => {
         shuffle(keys).slice(0, NUM_IMAGES).map(async (key): Promise<imageWithTitle | null> => {
             try {
                 const meta = await measureImage(key);
-                return { title: key, img: `${s3Url}/${encodeURI(key)}`, ...meta };
+                return { title: captionFor(key), img: `${s3Url}/${encodeURI(key)}`, ...meta };
             } catch (error) {
                 console.error(`Failed to measure gallery image ${key}`, error);
                 return null;

--- a/src/lib/captions.ts
+++ b/src/lib/captions.ts
@@ -1,0 +1,19 @@
+// Human-written captions for gallery photos, keyed by S3 object key.
+// Photos not listed here fall back to a prettified filename, so entries
+// are only needed where the filename isn't descriptive, e.g.:
+//   "IMG_1913.jpeg": "Maggie's first day home",
+const captions: Record<string, string> = {};
+
+// Turns an S3 key like "sad_maggie Large.jpeg" into "Sad Maggie".
+// The trailing "Large" is the size suffix Apple Photos adds on export.
+const prettifyKey = (key: string): string => {
+    const name = key
+        .split("/").pop()!
+        .replace(/\.[^.]+$/, "")
+        .replace(/[_-]+/g, " ")
+        .replace(/\s+(large|medium|small)$/i, "")
+        .trim();
+    return name.replace(/(^|\s)[a-z]/g, (letter) => letter.toUpperCase());
+};
+
+export const captionFor = (key: string): string => captions[key] ?? prettifyKey(key);


### PR DESCRIPTION
Closes #350

Gallery alt text and titles were raw S3 keys like `sad_maggie Large.jpeg`. The title passed to the components is now derived in `page.tsx` via a new `captionFor()`:

1. An explicit caption map in `src/lib/captions.ts` wins, keyed by S3 key — the place to caption photos whose filenames aren't descriptive (it starts empty with a usage example)
2. Otherwise the filename is prettified: extension stripped, Apple Photos' `Large`/`Medium`/`Small` export suffix removed, underscores/hyphens become spaces, words capitalized — `sad_maggie Large.jpeg` → `Sad Maggie`

Notes:
- I went with the repo map option rather than S3 object metadata: image metadata is fetched inside a permanently-cached `unstable_cache` entry (`revalidate: false`), so caption edits in S3 would never surface, while repo edits take effect on deploy
- Only `page.tsx` plus the new lib file change, so this doesn't conflict with the lightbox PR #379; components keep consuming `title` as before
- Verified by rendering the page: alt text now reads `Angry`, `Slipper`, `IMG 1889`, etc.