### PR TITLE
Fix thumbnail flicker on hover

### DIFF
--- a/src/components/MaggieImageList.tsx
+++ b/src/components/MaggieImageList.tsx
@@ -26,8 +26,10 @@ const MaggieImageList: FC<MaggieImageListProps> = ({ images }) => {
               <Image
                 // will-change keeps each thumbnail on its own compositor
                 // layer: promoting one mid-hover inside the multi-column
-                // layout makes Chromium briefly blank the image.
-                className='w-full h-auto rounded-lg transition duration-200 will-change-transform hover:scale-[1.02] hover:shadow-lg'
+                // layout makes Chromium briefly blank the image. Scoped to
+                // mouse-like pointers so touch screens (where the effect
+                // never fires) don't pay for a GPU layer per thumbnail.
+                className='w-full h-auto rounded-lg transition duration-200 pointer-fine:will-change-transform hover:scale-[1.02] hover:shadow-lg'
                 src={item.img}
                 alt={item.title}
                 loading='lazy'

--- a/src/components/MaggieImageList.tsx
+++ b/src/components/MaggieImageList.tsx
@@ -24,7 +24,10 @@ const MaggieImageList: FC<MaggieImageListProps> = ({ images }) => {
               aria-label={`View ${item.title}`}
             >
               <Image
-                className='w-full h-auto rounded-lg transition duration-200 hover:scale-[1.02] hover:shadow-lg'
+                // will-change keeps each thumbnail on its own compositor
+                // layer: promoting one mid-hover inside the multi-column
+                // layout makes Chromium briefly blank the image.
+                className='w-full h-auto rounded-lg transition duration-200 will-change-transform hover:scale-[1.02] hover:shadow-lg'
                 src={item.img}
                 alt={item.title}
                 loading='lazy'


### PR DESCRIPTION
Hovering a gallery thumbnail made the image briefly disappear, leaving the page background.

Root cause: the thumbnails live in a CSS multi-column masonry (`columns-2/3/4`), and the `hover:scale-[1.02]` transform promotes the image to its own compositor layer at hover time. In Chromium, that mid-layout promotion inside a fragmented (multicol) container repaints with a blank frame — the image vanishes for an instant.

Fix: `will-change-transform` on the thumbnail keeps it permanently on its own layer, so hover no longer triggers a promote/demote cycle. One-line class change; the hover effect itself is unchanged.

This is independent of the Blob migration (#382) — it's been latent since the hover polish, and the fix applies cleanly either side of that PR. Please confirm the flicker is gone on the preview deployment, since I can't reproduce a paint-timing bug from the CLI.