### PR TITLE
Expand CI: type check, migration validation, audit gate, CodeQL, dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,13 @@ updates:
       directory: "/" # Location of package manifests
       schedule:
           interval: "weekly"
+      # One PR per week for patches, one for minors; majors stay individual.
+      groups:
+          patch-updates:
+              update-types: ["patch"]
+          minor-updates:
+              update-types: ["minor"]
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: 'npm'
+    - run: npm ci
+    - run: npx tsc --noEmit
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+    # GHSA-f88m-g3jw-g9cj is Next's internally bundled sharp 0.34.x
+    # (libvips CVEs): every current Next release pins it, and it is dead
+    # code on Vercel, where next/image optimization runs in the platform
+    # image service. Remove the allowlist entry once Next bundles sharp
+    # >= 0.35.
+    - run: npx audit-ci --high --allowlist GHSA-f88m-g3jw-g9cj
+
+  migration-check:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+        - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: 'npm'
+    - run: npm ci
+    # A broken migration fails here, on an empty throwaway database,
+    # instead of against production.
+    - name: Apply all migrations to an empty database
+      run: npx prisma migrate deploy
+    # Fails if schema.prisma and the migration history disagree, which
+    # is how production drift starts.
+    - name: Check schema matches migration history
+      run: |
+        psql "$DATABASE_URL" -c 'CREATE DATABASE shadow;'
+        npx prisma migrate diff \
+          --from-migrations prisma/migrations \
+          --to-schema-datamodel prisma/schema.prisma \
+          --shadow-database-url postgresql://postgres:postgres@localhost:5432/shadow \
+          --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         node-version: 22.x
         cache: 'npm'
     - run: npm ci
+    # next-env.d.ts is gitignored, so generate Next's ambient types
+    # (static image imports, route types) before type checking.
+    - run: npx next typegen
     - run: npx tsc --noEmit
 
   audit:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,4 +60,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(npm ci),Bash(npm run lint),Bash(npx tsc --noEmit)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+  - cron: '30 4 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+    - uses: actions/checkout@v4
+    - uses: github/codeql-action/init@v3
+      with:
+        languages: javascript-typescript
+    - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+    - uses: dependabot/fetch-metadata@v2
+      id: metadata
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    # Patch bumps merge themselves once required checks pass; minors and
+    # majors wait for a human.
+    - if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+      run: gh pr merge --auto --squash "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,36 @@
+name: Migrate production database
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+    - 'prisma/migrations/**'
+    - 'prisma/schema.prisma'
+
+permissions:
+  contents: read
+
+# Serialize migration runs; never cancel one mid-flight.
+concurrency:
+  group: migrate-production
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: 'npm'
+    - run: npm ci
+    - name: Run migrations against production
+      env:
+        DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      run: |
+        if [ -z "$DATABASE_URL" ]; then
+          echo "::warning::DATABASE_URL secret not set; skipping migration deploy"
+          exit 0
+        fi
+        npx prisma migrate deploy

--- a/package-lock.json
+++ b/package-lock.json
@@ -4718,9 +4718,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -5281,34 +5281,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/next/node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -5733,9 +5705,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5752,7 +5724,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -31,5 +31,10 @@
     "eslint-config-next": "^15.5.21",
     "prisma": "^6.19.3",
     "typescript": "^5.7.2"
+  },
+  "overrides": {
+    "next": {
+      "postcss": "^8.5.16"
+    }
   }
 }


### PR DESCRIPTION
Implements the CI improvements discussed, all in one PR:

### New `ci.yml` (runs on this PR — self-verifying)
- **typecheck** — `tsc --noEmit`
- **migration-check** — applies the full migration history to an empty throwaway Postgres (broken SQL fails here, not against prod) and runs `prisma migrate diff --from-migrations --to-schema-datamodel --exit-code` to catch schema/history drift — the class of problem behind the P3018 incident
- **audit** — `audit-ci --high`, allowlisting exactly one advisory: Next's internally bundled sharp (GHSA-f88m-g3jw-g9cj), which every current Next pins and which is dead code on Vercel. Commented for removal once Next bundles sharp ≥ 0.35

### New `migrate.yml`
Runs `prisma migrate deploy` against production on pushes to main touching `prisma/` — serialized, never cancelled mid-run. **Manual steps to activate:**
1. Add the production `DATABASE_URL` as a repo Actions secret (until then the job skips with a warning)
2. Change the Vercel build command from `prisma generate && prisma migrate deploy && next build` to `prisma generate && next build` — after this, a bad migration is one red workflow instead of a blocked deploy pipeline

### New `codeql.yml`
JavaScript/TypeScript analysis on pushes, PRs, and weekly — free on a public repo.

### Dependabot
Weekly patch and minor rollup groups (majors stay individual), github-actions ecosystem now watched, and a new workflow auto-merges **patch** bumps via `gh pr merge --auto` once required checks pass. Repo auto-merge setting already enabled. Note: auto-merge is only as safe as your required status checks — worth marking `build`, `typecheck`, and `migration-check` as required in branch protection.

### Misc
- Review bot can now run `npm ci` / `npm run lint` / `npx tsc --noEmit` (it flagged the missing permission in every review today)
- Concurrency groups on lint/CI/CodeQL cancel superseded runs on force-push
- **Override pinning Next's nested postcss to ≥ 8.5.16**: two advisories published today (GHSA-qx2v-qp2m-jg93 XSS, GHSA-6g55-p6wh-862q file read) hit the postcss 8.4.31 that Next pins; unlike the sharp case this is override-fixable, keeping the audit gate honest

All commands validated locally before being committed: `tsc` clean, migration deploy + drift check green against a Docker Postgres 16, `audit-ci` passes with only the sharp allowlist, and the production build compiles with the postcss override in place.